### PR TITLE
Add RegexParser to convert regex strings to SuperExpressive code

### DIFF
--- a/src/Parser/Lexer.php
+++ b/src/Parser/Lexer.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser;
+
+use Bassim\SuperExpressive\RegexParseException;
+
+final class Lexer
+{
+    private const CHAR_CLASSES = [
+        'd' => 'digit',
+        'D' => 'nonDigit',
+        'w' => 'word',
+        'W' => 'nonWord',
+        's' => 'whitespace',
+        'S' => 'nonWhitespace',
+        'n' => 'newline',
+        'r' => 'carriageReturn',
+        't' => 'tab',
+        'b' => 'wordBoundary',
+        'B' => 'nonWordBoundary',
+    ];
+
+    private const VALID_DELIMITERS = ['/', '#', '~', '@', ';', '%', '`'];
+    private const VALID_FLAGS = ['i', 'm', 's', 'g', 'u', 'y'];
+
+    private string $input;
+    private string $pattern;
+    private int $pos = 0;
+
+    /** @var string[] */
+    private array $flags = [];
+
+    public function __construct(string $input)
+    {
+        $this->input = $input;
+        $this->extractDelimitersAndFlags();
+    }
+
+    /**
+     * @return Token[]
+     */
+    public function tokenize(): array
+    {
+        $tokens = [];
+
+        while (!$this->eof()) {
+            $token = $this->nextToken();
+            if ($token !== null) {
+                $tokens[] = $token;
+            }
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFlags(): array
+    {
+        return $this->flags;
+    }
+
+    private function nextToken(): ?Token
+    {
+        $char = $this->peek();
+        $pos = $this->pos;
+
+        // Order matters - check multi-char patterns first
+        return $this->matchEscape($pos)
+            ?? $this->matchAnchor($char, $pos)
+            ?? $this->matchDot($char, $pos)
+            ?? $this->matchCharSet($char, $pos)
+            ?? $this->matchGroup($char, $pos)
+            ?? $this->matchQuantifier($char, $pos)
+            ?? $this->matchLiteral($char, $pos);
+    }
+
+    private function matchEscape(int $pos): ?Token
+    {
+        if ($this->peek() !== '\\') {
+            return null;
+        }
+
+        $this->advance(); // consume \
+        $char = $this->advance();
+
+        if ($char === null) {
+            throw new RegexParseException('Incomplete escape sequence', $this->input, $pos);
+        }
+
+        if (isset(self::CHAR_CLASSES[$char])) {
+            return new Token(Token::CHAR_CLASS, self::CHAR_CLASSES[$char], $pos);
+        }
+
+        if (ctype_digit($char)) {
+            throw new RegexParseException('Backreferences are not supported', $this->input, $pos);
+        }
+
+        return new Token(Token::LITERAL, $char, $pos);
+    }
+
+    private function matchAnchor(string $char, int $pos): ?Token
+    {
+        if ($char === '^') {
+            $this->advance();
+            return new Token(Token::ANCHOR_START, '^', $pos);
+        }
+
+        if ($char === '$') {
+            $this->advance();
+            return new Token(Token::ANCHOR_END, '$', $pos);
+        }
+
+        return null;
+    }
+
+    private function matchDot(string $char, int $pos): ?Token
+    {
+        if ($char !== '.') {
+            return null;
+        }
+
+        $this->advance();
+        return new Token(Token::DOT, '.', $pos);
+    }
+
+    private function matchCharSet(string $char, int $pos): ?Token
+    {
+        if ($char !== '[') {
+            return null;
+        }
+
+        $this->advance();
+        $negated = false;
+
+        if ($this->peek() === '^') {
+            $negated = true;
+            $this->advance();
+        }
+
+        $items = [];
+        while (!$this->eof() && $this->peek() !== ']') {
+            $c = $this->readCharSetChar();
+
+            if ($this->peek() === '-' && $this->peek(1) !== null && $this->peek(1) !== ']') {
+                $this->advance();
+                $end = $this->readCharSetChar();
+                $items[] = ['type' => 'range', 'from' => $c, 'to' => $end];
+            } else {
+                $items[] = ['type' => 'char', 'value' => $c];
+            }
+        }
+
+        if ($this->peek() !== ']') {
+            throw new RegexParseException('Unclosed character set', $this->input, $pos);
+        }
+        $this->advance();
+
+        return new Token(Token::CHAR_SET, $items, $pos, ['negated' => $negated]);
+    }
+
+    private function readCharSetChar(): string
+    {
+        if ($this->peek() === '\\') {
+            $this->advance();
+            $c = $this->advance();
+            return $this->unescapeCharSetChar($c);
+        }
+
+        return $this->advance();
+    }
+
+    private function unescapeCharSetChar(?string $char): string
+    {
+        $map = [
+            'n' => "\n",
+            'r' => "\r",
+            't' => "\t",
+            '\\' => '\\',
+            ']' => ']',
+            '[' => '[',
+            '-' => '-',
+            '^' => '^',
+        ];
+
+        return $map[$char] ?? $char;
+    }
+
+    private function matchGroup(string $char, int $pos): ?Token
+    {
+        if ($char !== '(') {
+            return null;
+        }
+
+        $this->advance();
+
+        if ($this->peek() === ')') {
+            $this->advance();
+            return null; // Empty group, skip
+        }
+
+        if ($this->peek() !== '?') {
+            return new Token(Token::GROUP_START, '(', $pos);
+        }
+
+        // Special group types
+        $second = $this->peek(1);
+        $third = $this->peek(2);
+
+        $groupTypes = [
+            [':',  null, Token::GROUP_NC_START, 2],
+            ['=',  null, Token::LOOKAHEAD, 2],
+            ['!',  null, Token::NEGATIVE_LOOKAHEAD, 2],
+            ['<',  '=',  Token::LOOKBEHIND, 3],
+            ['<',  '!',  Token::NEGATIVE_LOOKBEHIND, 3],
+        ];
+
+        foreach ($groupTypes as [$s, $t, $type, $skip]) {
+            if ($second === $s && ($t === null || $third === $t)) {
+                for ($i = 0; $i < $skip; $i++) {
+                    $this->advance();
+                }
+                return new Token($type, $type, $pos);
+            }
+        }
+
+        throw new RegexParseException('Unsupported group type (named groups not supported)', $this->input, $pos);
+    }
+
+    private function matchQuantifier(string $char, int $pos): ?Token
+    {
+        if ($char === ')') {
+            $this->advance();
+            return new Token(Token::GROUP_END, ')', $pos);
+        }
+
+        if ($char === '|') {
+            throw new RegexParseException('Alternation (|) is not supported', $this->input, $pos);
+        }
+
+        if (\in_array($char, ['+', '*', '?'], true)) {
+            $this->advance();
+            $lazy = $this->peek() === '?';
+            if ($lazy) {
+                $this->advance();
+            }
+
+            $bounds = ['+' => [1, null], '*' => [0, null], '?' => [0, 1]];
+            [$min, $max] = $bounds[$char];
+
+            return new Token(Token::QUANTIFIER, $char, $pos, [
+                'min' => $min,
+                'max' => $max,
+                'lazy' => $lazy,
+            ]);
+        }
+
+        if ($char === '{') {
+            return $this->readBraceQuantifier($pos);
+        }
+
+        return null;
+    }
+
+    private function readBraceQuantifier(int $pos): Token
+    {
+        $this->advance();
+
+        $min = $this->readNumber();
+        if ($min === null) {
+            throw new RegexParseException('Invalid quantifier: expected number', $this->input, $pos);
+        }
+
+        $max = $min;
+        if ($this->peek() === ',') {
+            $this->advance();
+            $max = $this->readNumber(); // null means unbounded
+        }
+
+        if ($this->peek() !== '}') {
+            throw new RegexParseException('Invalid quantifier: expected }', $this->input, $this->pos);
+        }
+        $this->advance();
+
+        $lazy = $this->peek() === '?';
+        if ($lazy) {
+            $this->advance();
+        }
+
+        return new Token(Token::QUANTIFIER, 'brace', $pos, [
+            'min' => $min,
+            'max' => $max,
+            'lazy' => $lazy,
+        ]);
+    }
+
+    private function readNumber(): ?int
+    {
+        $num = '';
+        while ($this->peek() !== null && ctype_digit($this->peek())) {
+            $num .= $this->advance();
+        }
+        return $num === '' ? null : (int) $num;
+    }
+
+    private function matchLiteral(string $char, int $pos): Token
+    {
+        $this->advance();
+        return new Token(Token::LITERAL, $char, $pos);
+    }
+
+    private function extractDelimitersAndFlags(): void
+    {
+        $regex = $this->input;
+
+        if (\strlen($regex) < 2) {
+            throw new RegexParseException('Invalid regex: too short', $regex, 0);
+        }
+
+        $delimiter = $regex[0];
+        if (!\in_array($delimiter, self::VALID_DELIMITERS, true)) {
+            throw new RegexParseException("Invalid delimiter: {$delimiter}", $regex, 0);
+        }
+
+        $lastPos = strrpos($regex, $delimiter, 1);
+        if ($lastPos === false) {
+            throw new RegexParseException('Missing closing delimiter', $regex, \strlen($regex));
+        }
+
+        $this->pattern = substr($regex, 1, $lastPos - 1);
+
+        $flagStr = substr($regex, $lastPos + 1);
+        for ($i = 0; $i < \strlen($flagStr); $i++) {
+            $flag = $flagStr[$i];
+            if (!\in_array($flag, self::VALID_FLAGS, true)) {
+                throw new RegexParseException("Unknown flag: {$flag}", $this->input, $lastPos + 1 + $i);
+            }
+            $this->flags[] = $flag;
+        }
+    }
+
+    private function peek(int $offset = 0): ?string
+    {
+        $p = $this->pos + $offset;
+        return $p < \strlen($this->pattern) ? $this->pattern[$p] : null;
+    }
+
+    private function advance(): ?string
+    {
+        return $this->eof() ? null : $this->pattern[$this->pos++];
+    }
+
+    private function eof(): bool
+    {
+        return $this->pos >= \strlen($this->pattern);
+    }
+}

--- a/src/Parser/Node.php
+++ b/src/Parser/Node.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser;
+
+abstract class Node
+{
+    public ?Quantifier $quantifier = null;
+
+    public function quantify(Quantifier $q): self
+    {
+        $this->quantifier = $q;
+        return $this;
+    }
+
+    abstract public function toSuperExpressive(): string;
+
+    protected function wrapWithQuantifier(string $method): string
+    {
+        if ($this->quantifier === null) {
+            return $method;
+        }
+        return $this->quantifier->toMethod() . '->' . $method;
+    }
+}

--- a/src/Parser/Nodes/CharSetNode.php
+++ b/src/Parser/Nodes/CharSetNode.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser\Nodes;
+
+use Bassim\SuperExpressive\Parser\Node;
+
+final class CharSetNode extends Node
+{
+    /** @var array<array{type: string, value?: string, from?: string, to?: string}> */
+    private array $items;
+    private bool $negated;
+
+    /**
+     * @param array<array{type: string, value?: string, from?: string, to?: string}> $items
+     */
+    public function __construct(array $items, bool $negated)
+    {
+        $this->items = $items;
+        $this->negated = $negated;
+    }
+
+    public function toSuperExpressive(): string
+    {
+        // Optimize: all simple chars
+        if ($this->allChars()) {
+            $chars = $this->collectChars();
+            $escaped = addcslashes($chars, "'\\");
+            $method = $this->negated ? "anythingButChars('{$escaped}')" : "anyOfChars('{$escaped}')";
+            return $this->wrapWithQuantifier($method);
+        }
+
+        // Optimize: single range
+        if (\count($this->items) === 1 && $this->items[0]['type'] === 'range') {
+            $from = $this->items[0]['from'];
+            $to = $this->items[0]['to'];
+            $method = $this->negated
+                ? "anythingButRange('{$from}', '{$to}')"
+                : "range('{$from}', '{$to}')";
+            return $this->wrapWithQuantifier($method);
+        }
+
+        // Complex: use anyOf()
+        return $this->generateComplex();
+    }
+
+    private function allChars(): bool
+    {
+        foreach ($this->items as $item) {
+            if ($item['type'] !== 'char') {
+                return false;
+            }
+        }
+        return \count($this->items) > 0;
+    }
+
+    private function collectChars(): string
+    {
+        $chars = '';
+        foreach ($this->items as $item) {
+            $chars .= $item['value'];
+        }
+        return $chars;
+    }
+
+    private function generateComplex(): string
+    {
+        $q = $this->quantifier !== null ? $this->quantifier->toMethod() . '->' : '';
+        $lines = [$q . 'anyOf()'];
+
+        foreach ($this->items as $item) {
+            if ($item['type'] === 'char') {
+                $escaped = addcslashes($item['value'], "'\\");
+                $lines[] = "    char('{$escaped}')";
+            } else {
+                $lines[] = "    range('{$item['from']}', '{$item['to']}')";
+            }
+        }
+
+        $lines[] = 'end()';
+        return implode("\n", $lines);
+    }
+}

--- a/src/Parser/Nodes/ContainerNode.php
+++ b/src/Parser/Nodes/ContainerNode.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser\Nodes;
+
+use Bassim\SuperExpressive\Parser\Node;
+
+final class ContainerNode extends Node
+{
+    private const METHODS = [
+        'group' => 'group()',
+        'capture' => 'capture()',
+        'assertAhead' => 'assertAhead()',
+        'assertNotAhead' => 'assertNotAhead()',
+        'assertBehind' => 'assertBehind()',
+        'assertNotBehind' => 'assertNotBehind()',
+    ];
+
+    private string $type;
+
+    /** @var Node[] */
+    private array $children;
+
+    /**
+     * @param Node[] $children
+     */
+    public function __construct(string $type, array $children)
+    {
+        $this->type = $type;
+        $this->children = $children;
+    }
+
+    public function toSuperExpressive(): string
+    {
+        $q = $this->quantifier !== null ? $this->quantifier->toMethod() . '->' : '';
+        $lines = [$q . self::METHODS[$this->type]];
+
+        foreach ($this->children as $child) {
+            $childCode = $child->toSuperExpressive();
+            foreach (explode("\n", $childCode) as $line) {
+                $lines[] = '    ' . $line;
+            }
+        }
+
+        $lines[] = 'end()';
+        return implode("\n", $lines);
+    }
+}

--- a/src/Parser/Nodes/FlagNode.php
+++ b/src/Parser/Nodes/FlagNode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser\Nodes;
+
+use Bassim\SuperExpressive\Parser\Node;
+
+final class FlagNode extends Node
+{
+    private const METHODS = [
+        'i' => 'caseInsensitive()',
+        'm' => 'lineByLine()',
+        's' => 'singleLine()',
+    ];
+
+    private string $flag;
+
+    public function __construct(string $flag)
+    {
+        $this->flag = $flag;
+    }
+
+    public function toSuperExpressive(): string
+    {
+        return self::METHODS[$this->flag] ?? '';
+    }
+}

--- a/src/Parser/Nodes/LiteralNode.php
+++ b/src/Parser/Nodes/LiteralNode.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser\Nodes;
+
+use Bassim\SuperExpressive\Parser\Node;
+
+final class LiteralNode extends Node
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function toSuperExpressive(): string
+    {
+        $escaped = addcslashes($this->value, "'\\");
+
+        if (\strlen($this->value) === 1) {
+            return $this->wrapWithQuantifier("char('{$escaped}')");
+        }
+
+        // Strings can't have quantifiers applied directly
+        return "string('{$escaped}')";
+    }
+}

--- a/src/Parser/Nodes/SimpleNode.php
+++ b/src/Parser/Nodes/SimpleNode.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser\Nodes;
+
+use Bassim\SuperExpressive\Parser\Node;
+
+final class SimpleNode extends Node
+{
+    private const METHODS = [
+        'startOfInput' => 'startOfInput()',
+        'endOfInput' => 'endOfInput()',
+        'digit' => 'digit()',
+        'nonDigit' => 'nonDigit()',
+        'word' => 'word()',
+        'nonWord' => 'nonWord()',
+        'whitespace' => 'whitespaceChar()',
+        'nonWhitespace' => 'nonWhitespaceChar()',
+        'anyChar' => 'anyChar()',
+        'newline' => 'newline()',
+        'carriageReturn' => 'carriageReturn()',
+        'tab' => 'tab()',
+        'wordBoundary' => 'wordBoundary()',
+        'nonWordBoundary' => 'nonWordBoundary()',
+    ];
+
+    private string $type;
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+
+    public function toSuperExpressive(): string
+    {
+        return $this->wrapWithQuantifier(self::METHODS[$this->type]);
+    }
+}

--- a/src/Parser/Quantifier.php
+++ b/src/Parser/Quantifier.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser;
+
+final class Quantifier
+{
+    public int $min;
+    public ?int $max;
+    public bool $lazy;
+
+    public function __construct(int $min, ?int $max, bool $lazy = false)
+    {
+        $this->min = $min;
+        $this->max = $max;
+        $this->lazy = $lazy;
+    }
+
+    public function toMethod(): string
+    {
+        if ($this->min === 0 && $this->max === 1) {
+            return 'optional()';
+        }
+
+        if ($this->min === 0 && $this->max === null) {
+            return $this->lazy ? 'zeroOrMoreLazy()' : 'zeroOrMore()';
+        }
+
+        if ($this->min === 1 && $this->max === null) {
+            return $this->lazy ? 'oneOrMoreLazy()' : 'oneOrMore()';
+        }
+
+        if ($this->min === $this->max) {
+            return "exactly({$this->min})";
+        }
+
+        if ($this->max === null) {
+            return "atLeast({$this->min})";
+        }
+
+        return $this->lazy
+            ? "betweenLazy({$this->min}, {$this->max})"
+            : "between({$this->min}, {$this->max})";
+    }
+}

--- a/src/Parser/Token.php
+++ b/src/Parser/Token.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Parser;
+
+final class Token
+{
+    public const ANCHOR_START = 'ANCHOR_START';
+    public const ANCHOR_END = 'ANCHOR_END';
+    public const CHAR_CLASS = 'CHAR_CLASS';
+    public const DOT = 'DOT';
+    public const CHAR_SET = 'CHAR_SET';
+    public const GROUP_START = 'GROUP_START';
+    public const GROUP_NC_START = 'GROUP_NC_START';
+    public const LOOKAHEAD = 'LOOKAHEAD';
+    public const NEGATIVE_LOOKAHEAD = 'NEGATIVE_LOOKAHEAD';
+    public const LOOKBEHIND = 'LOOKBEHIND';
+    public const NEGATIVE_LOOKBEHIND = 'NEGATIVE_LOOKBEHIND';
+    public const GROUP_END = 'GROUP_END';
+    public const QUANTIFIER = 'QUANTIFIER';
+    public const LITERAL = 'LITERAL';
+
+    public string $type;
+    public int $position;
+
+    /** @var mixed */
+    public $value;
+
+    /** @var array<string, mixed> */
+    public array $meta;
+
+    /**
+     * @param mixed $value
+     * @param array<string, mixed> $meta
+     */
+    public function __construct(string $type, $value, int $position, array $meta = [])
+    {
+        $this->type = $type;
+        $this->value = $value;
+        $this->position = $position;
+        $this->meta = $meta;
+    }
+
+    public function is(string $type): bool
+    {
+        return $this->type === $type;
+    }
+}

--- a/src/RegexParseException.php
+++ b/src/RegexParseException.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive;
+
+class RegexParseException extends \RuntimeException
+{
+    private string $regexInput;
+    private int $regexPosition;
+
+    public function __construct(
+        string $message,
+        string $input,
+        int $position,
+        ?\Throwable $previous = null
+    ) {
+        $this->regexInput = $input;
+        $this->regexPosition = $position;
+
+        $contextMessage = sprintf(
+            "%s at position %d: %s",
+            $message,
+            $position,
+            $this->getContext($input, $position)
+        );
+
+        parent::__construct($contextMessage, 0, $previous);
+    }
+
+    public function getRegexInput(): string
+    {
+        return $this->regexInput;
+    }
+
+    public function getRegexPosition(): int
+    {
+        return $this->regexPosition;
+    }
+
+    private function getContext(string $input, int $position): string
+    {
+        $start = max(0, $position - 10);
+        $end = min(\strlen($input), $position + 10);
+        $context = substr($input, $start, $end - $start);
+        $pointerPos = min($position, 10);
+
+        return sprintf("\n  %s\n  %s^", $context, str_repeat(' ', $pointerPos));
+    }
+}

--- a/src/RegexParser.php
+++ b/src/RegexParser.php
@@ -1,0 +1,807 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive;
+
+final class RegexParser
+{
+    // Token types
+    private const TOKEN_ANCHOR_START = 'ANCHOR_START';
+    private const TOKEN_ANCHOR_END = 'ANCHOR_END';
+    private const TOKEN_CHAR_CLASS = 'CHAR_CLASS';
+    private const TOKEN_DOT = 'DOT';
+    private const TOKEN_CHAR_SET_START = 'CHAR_SET_START';
+    private const TOKEN_CHAR_SET_END = 'CHAR_SET_END';
+    private const TOKEN_GROUP_START = 'GROUP_START';
+    private const TOKEN_GROUP_NC_START = 'GROUP_NC_START';
+    private const TOKEN_GROUP_END = 'GROUP_END';
+    private const TOKEN_QUANTIFIER = 'QUANTIFIER';
+    private const TOKEN_LITERAL = 'LITERAL';
+
+    // Method mappings
+    private const CHAR_CLASS_MAP = [
+        'd' => 'digit',
+        'D' => 'nonDigit',
+        'w' => 'word',
+        'W' => 'nonWord',
+        's' => 'whitespace',
+        'S' => 'nonWhitespace',
+    ];
+
+    private const METHOD_MAP = [
+        'digit' => 'digit()',
+        'nonDigit' => 'nonDigit()',
+        'word' => 'word()',
+        'nonWord' => 'nonWord()',
+        'whitespace' => 'whitespaceChar()',
+        'nonWhitespace' => 'nonWhitespaceChar()',
+        'anyChar' => 'anyChar()',
+        'startOfInput' => 'startOfInput()',
+        'endOfInput' => 'endOfInput()',
+        'newline' => 'newline()',
+        'carriageReturn' => 'carriageReturn()',
+        'tab' => 'tab()',
+    ];
+
+    private const FLAG_MAP = [
+        'i' => 'caseInsensitive()',
+        'm' => 'lineByLine()',
+        's' => 'singleLine()',
+    ];
+
+    private string $input;
+    private string $pattern;
+    private int $position = 0;
+    private array $tokens = [];
+    private array $flags = [];
+
+    private function __construct(string $regex)
+    {
+        $this->input = $regex;
+    }
+
+    public static function parse(string $regex): string
+    {
+        $parser = new self($regex);
+        $parser->extractDelimitersAndFlags();
+        $parser->tokenize();
+        $ast = $parser->parseTokens();
+
+        return $parser->generate($ast);
+    }
+
+    // =========================================================================
+    // LEXER
+    // =========================================================================
+
+    private function extractDelimitersAndFlags(): void
+    {
+        $regex = $this->input;
+
+        if (\strlen($regex) < 2) {
+            throw new RegexParseException('Invalid regex: too short', $regex, 0);
+        }
+
+        $delimiter = $regex[0];
+        if (!$this->isValidDelimiter($delimiter)) {
+            throw new RegexParseException("Invalid delimiter: {$delimiter}", $regex, 0);
+        }
+
+        $lastDelimiterPos = strrpos($regex, $delimiter, 1);
+        if ($lastDelimiterPos === false) {
+            throw new RegexParseException('Missing closing delimiter', $regex, \strlen($regex));
+        }
+
+        $this->pattern = substr($regex, 1, $lastDelimiterPos - 1);
+        $flagString = substr($regex, $lastDelimiterPos + 1);
+
+        for ($i = 0; $i < \strlen($flagString); $i++) {
+            $flag = $flagString[$i];
+            if (isset(self::FLAG_MAP[$flag])) {
+                $this->flags[] = $flag;
+            } elseif ($flag === 'g' || $flag === 'u' || $flag === 'y') {
+                $this->flags[] = $flag;
+            } else {
+                throw new RegexParseException("Unknown flag: {$flag}", $this->input, $lastDelimiterPos + 1 + $i);
+            }
+        }
+    }
+
+    private function isValidDelimiter(string $char): bool
+    {
+        return \in_array($char, ['/', '#', '~', '@', ';', '%', '`'], true);
+    }
+
+    private function tokenize(): void
+    {
+        $this->position = 0;
+        $this->tokens = [];
+
+        while (!$this->isAtEnd()) {
+            $token = $this->readToken();
+            if ($token !== null) {
+                $this->tokens[] = $token;
+            }
+        }
+    }
+
+    private function readToken(): ?array
+    {
+        $char = $this->peek();
+        $pos = $this->position;
+
+        // Escape sequences
+        if ($char === '\\') {
+            return $this->readEscapeSequence();
+        }
+
+        // Anchors
+        if ($char === '^') {
+            $this->advance();
+            return ['type' => self::TOKEN_ANCHOR_START, 'value' => '^', 'position' => $pos];
+        }
+
+        if ($char === '$') {
+            $this->advance();
+            return ['type' => self::TOKEN_ANCHOR_END, 'value' => '$', 'position' => $pos];
+        }
+
+        // Dot
+        if ($char === '.') {
+            $this->advance();
+            return ['type' => self::TOKEN_DOT, 'value' => '.', 'position' => $pos];
+        }
+
+        // Character set
+        if ($char === '[') {
+            return $this->readCharacterSet();
+        }
+
+        // Groups
+        if ($char === '(') {
+            $this->advance();
+            if ($this->peek() === '?' && $this->peek(1) === ':') {
+                $this->advance();
+                $this->advance();
+                return ['type' => self::TOKEN_GROUP_NC_START, 'value' => '(?:', 'position' => $pos];
+            }
+            if ($this->peek() === '?') {
+                throw new RegexParseException(
+                    'Unsupported group type (lookahead/lookbehind/named groups not supported in v1)',
+                    $this->input,
+                    $pos
+                );
+            }
+            return ['type' => self::TOKEN_GROUP_START, 'value' => '(', 'position' => $pos];
+        }
+
+        if ($char === ')') {
+            $this->advance();
+            return ['type' => self::TOKEN_GROUP_END, 'value' => ')', 'position' => $pos];
+        }
+
+        // Quantifiers
+        if (\in_array($char, ['+', '*', '?'], true)) {
+            return $this->readQuantifier();
+        }
+
+        if ($char === '{') {
+            return $this->readBraceQuantifier();
+        }
+
+        // Alternation
+        if ($char === '|') {
+            throw new RegexParseException(
+                'Alternation (|) outside of anyOf context is not supported in v1',
+                $this->input,
+                $pos
+            );
+        }
+
+        // Literal
+        $this->advance();
+        return ['type' => self::TOKEN_LITERAL, 'value' => $char, 'position' => $pos];
+    }
+
+    private function readEscapeSequence(): array
+    {
+        $pos = $this->position;
+        $this->advance(); // consume \
+
+        $char = $this->peek();
+        if ($char === null) {
+            throw new RegexParseException('Incomplete escape sequence', $this->input, $pos);
+        }
+
+        $this->advance();
+
+        // Character classes
+        if (isset(self::CHAR_CLASS_MAP[$char])) {
+            return [
+                'type' => self::TOKEN_CHAR_CLASS,
+                'value' => self::CHAR_CLASS_MAP[$char],
+                'position' => $pos,
+            ];
+        }
+
+        // Special characters
+        if ($char === 'n') {
+            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'newline', 'position' => $pos];
+        }
+        if ($char === 'r') {
+            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'carriageReturn', 'position' => $pos];
+        }
+        if ($char === 't') {
+            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'tab', 'position' => $pos];
+        }
+
+        // Word boundary
+        if ($char === 'b') {
+            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'wordBoundary', 'position' => $pos];
+        }
+        if ($char === 'B') {
+            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'nonWordBoundary', 'position' => $pos];
+        }
+
+        // Backreference check
+        if (ctype_digit($char)) {
+            throw new RegexParseException('Backreferences are not supported in v1', $this->input, $pos);
+        }
+
+        // Escaped literal
+        return ['type' => self::TOKEN_LITERAL, 'value' => $char, 'position' => $pos];
+    }
+
+    private function readQuantifier(): array
+    {
+        $pos = $this->position;
+        $char = $this->advance();
+        $lazy = false;
+
+        if ($this->peek() === '?') {
+            $this->advance();
+            $lazy = true;
+        }
+
+        return [
+            'type' => self::TOKEN_QUANTIFIER,
+            'value' => $char,
+            'position' => $pos,
+            'lazy' => $lazy,
+            'min' => $char === '+' ? 1 : 0,
+            'max' => $char === '?' ? 1 : null,
+        ];
+    }
+
+    private function readBraceQuantifier(): array
+    {
+        $pos = $this->position;
+        $this->advance(); // consume {
+
+        $numStr = '';
+        while ($this->peek() !== null && ctype_digit($this->peek())) {
+            $numStr .= $this->advance();
+        }
+
+        if ($numStr === '') {
+            throw new RegexParseException('Invalid quantifier: expected number', $this->input, $pos);
+        }
+
+        $min = (int) $numStr;
+        $max = $min;
+
+        if ($this->peek() === ',') {
+            $this->advance();
+            $maxStr = '';
+            while ($this->peek() !== null && ctype_digit($this->peek())) {
+                $maxStr .= $this->advance();
+            }
+            $max = $maxStr === '' ? null : (int) $maxStr;
+        }
+
+        if ($this->peek() !== '}') {
+            throw new RegexParseException('Invalid quantifier: expected }', $this->input, $this->position);
+        }
+        $this->advance();
+
+        $lazy = false;
+        if ($this->peek() === '?') {
+            $this->advance();
+            $lazy = true;
+        }
+
+        return [
+            'type' => self::TOKEN_QUANTIFIER,
+            'value' => 'brace',
+            'position' => $pos,
+            'lazy' => $lazy,
+            'min' => $min,
+            'max' => $max,
+        ];
+    }
+
+    private function readCharacterSet(): array
+    {
+        $pos = $this->position;
+        $this->advance(); // consume [
+
+        $negated = false;
+        if ($this->peek() === '^') {
+            $negated = true;
+            $this->advance();
+        }
+
+        $items = [];
+        while ($this->peek() !== null && $this->peek() !== ']') {
+            $char = $this->peek();
+
+            if ($char === '\\') {
+                $this->advance();
+                $escaped = $this->advance();
+                if ($escaped === null) {
+                    throw new RegexParseException('Incomplete escape in character set', $this->input, $this->position);
+                }
+                $char = $this->resolveEscapeInCharSet($escaped);
+            } else {
+                $this->advance();
+            }
+
+            // Check for range
+            if ($this->peek() === '-' && $this->peek(1) !== null && $this->peek(1) !== ']') {
+                $this->advance(); // consume -
+                $endChar = $this->peek();
+                if ($endChar === '\\') {
+                    $this->advance();
+                    $endChar = $this->resolveEscapeInCharSet($this->advance());
+                } else {
+                    $this->advance();
+                }
+                $items[] = ['type' => 'range', 'from' => $char, 'to' => $endChar];
+            } else {
+                $items[] = ['type' => 'char', 'value' => $char];
+            }
+        }
+
+        if ($this->peek() !== ']') {
+            throw new RegexParseException('Unclosed character set', $this->input, $pos);
+        }
+        $this->advance();
+
+        return [
+            'type' => self::TOKEN_CHAR_SET_START,
+            'value' => $items,
+            'position' => $pos,
+            'negated' => $negated,
+        ];
+    }
+
+    private function resolveEscapeInCharSet(string $char): string
+    {
+        $map = ['n' => "\n", 'r' => "\r", 't' => "\t", '\\' => '\\', ']' => ']', '[' => '[', '-' => '-', '^' => '^'];
+        return $map[$char] ?? $char;
+    }
+
+    private function peek(int $offset = 0): ?string
+    {
+        $pos = $this->position + $offset;
+        return $pos < \strlen($this->pattern) ? $this->pattern[$pos] : null;
+    }
+
+    private function advance(): ?string
+    {
+        if ($this->isAtEnd()) {
+            return null;
+        }
+        return $this->pattern[$this->position++];
+    }
+
+    private function isAtEnd(): bool
+    {
+        return $this->position >= \strlen($this->pattern);
+    }
+
+    // =========================================================================
+    // PARSER
+    // =========================================================================
+
+    private int $tokenIndex = 0;
+
+    private function parseTokens(): array
+    {
+        $this->tokenIndex = 0;
+        $children = [];
+
+        // Add flags first
+        foreach ($this->flags as $flag) {
+            if (isset(self::FLAG_MAP[$flag])) {
+                $children[] = ['type' => 'flag', 'value' => $flag];
+            }
+        }
+
+        // Parse expression
+        while ($this->tokenIndex < \count($this->tokens)) {
+            $node = $this->parseAtom();
+            if ($node !== null) {
+                $children[] = $node;
+            }
+        }
+
+        return ['type' => 'root', 'children' => $children];
+    }
+
+    private function parseAtom(): ?array
+    {
+        if ($this->tokenIndex >= \count($this->tokens)) {
+            return null;
+        }
+
+        $token = $this->tokens[$this->tokenIndex];
+
+        switch ($token['type']) {
+            case self::TOKEN_ANCHOR_START:
+                $this->tokenIndex++;
+                return ['type' => 'startOfInput'];
+
+            case self::TOKEN_ANCHOR_END:
+                $this->tokenIndex++;
+                return ['type' => 'endOfInput'];
+
+            case self::TOKEN_CHAR_CLASS:
+                $this->tokenIndex++;
+                $node = ['type' => $token['value']];
+                return $this->applyQuantifierIfPresent($node);
+
+            case self::TOKEN_DOT:
+                $this->tokenIndex++;
+                $node = ['type' => 'anyChar'];
+                return $this->applyQuantifierIfPresent($node);
+
+            case self::TOKEN_LITERAL:
+                return $this->parseLiterals();
+
+            case self::TOKEN_CHAR_SET_START:
+                $this->tokenIndex++;
+                $node = $this->buildCharSetNode($token);
+                return $this->applyQuantifierIfPresent($node);
+
+            case self::TOKEN_GROUP_START:
+            case self::TOKEN_GROUP_NC_START:
+                return $this->parseGroup($token['type'] === self::TOKEN_GROUP_START);
+
+            case self::TOKEN_GROUP_END:
+                return null;
+
+            case self::TOKEN_QUANTIFIER:
+                throw new RegexParseException(
+                    'Unexpected quantifier without preceding element',
+                    $this->input,
+                    $token['position']
+                );
+
+            default:
+                $this->tokenIndex++;
+                return null;
+        }
+    }
+
+    private function parseLiterals(): array
+    {
+        $literals = '';
+        $startPos = $this->tokenIndex;
+
+        // Collect consecutive literals
+        while ($this->tokenIndex < \count($this->tokens)) {
+            $token = $this->tokens[$this->tokenIndex];
+            if ($token['type'] !== self::TOKEN_LITERAL) {
+                break;
+            }
+
+            // Check if next token is a quantifier
+            $nextToken = $this->tokens[$this->tokenIndex + 1] ?? null;
+            if ($nextToken && $nextToken['type'] === self::TOKEN_QUANTIFIER) {
+                // If we have accumulated literals, return them first
+                if (\strlen($literals) > 0) {
+                    break;
+                }
+                // Otherwise, this single char gets quantified
+                $this->tokenIndex++;
+                $node = ['type' => 'char', 'value' => $token['value']];
+                return $this->applyQuantifierIfPresent($node);
+            }
+
+            $literals .= $token['value'];
+            $this->tokenIndex++;
+        }
+
+        if (\strlen($literals) === 1) {
+            return ['type' => 'char', 'value' => $literals];
+        }
+
+        return ['type' => 'string', 'value' => $literals];
+    }
+
+    private function buildCharSetNode(array $token): array
+    {
+        $items = $token['value'];
+        $negated = $token['negated'];
+
+        // Optimize: simple chars only
+        $allChars = true;
+        $chars = '';
+        foreach ($items as $item) {
+            if ($item['type'] === 'char') {
+                $chars .= $item['value'];
+            } else {
+                $allChars = false;
+                break;
+            }
+        }
+
+        if ($allChars && \strlen($chars) > 0) {
+            return [
+                'type' => $negated ? 'anythingButChars' : 'anyOfChars',
+                'value' => $chars,
+            ];
+        }
+
+        // Single range
+        if (\count($items) === 1 && $items[0]['type'] === 'range') {
+            if ($negated) {
+                return [
+                    'type' => 'anythingButRange',
+                    'from' => $items[0]['from'],
+                    'to' => $items[0]['to'],
+                ];
+            }
+            return [
+                'type' => 'range',
+                'from' => $items[0]['from'],
+                'to' => $items[0]['to'],
+            ];
+        }
+
+        // Complex: use anyOf
+        return [
+            'type' => 'charSet',
+            'items' => $items,
+            'negated' => $negated,
+        ];
+    }
+
+    private function parseGroup(bool $capturing): array
+    {
+        $this->tokenIndex++; // consume group start
+
+        $children = [];
+        while ($this->tokenIndex < \count($this->tokens)) {
+            $token = $this->tokens[$this->tokenIndex];
+            if ($token['type'] === self::TOKEN_GROUP_END) {
+                $this->tokenIndex++;
+                break;
+            }
+            $node = $this->parseAtom();
+            if ($node !== null) {
+                $children[] = $node;
+            }
+        }
+
+        $node = [
+            'type' => $capturing ? 'capture' : 'group',
+            'children' => $children,
+        ];
+
+        return $this->applyQuantifierIfPresent($node);
+    }
+
+    private function applyQuantifierIfPresent(array $node): array
+    {
+        if ($this->tokenIndex >= \count($this->tokens)) {
+            return $node;
+        }
+
+        $token = $this->tokens[$this->tokenIndex];
+        if ($token['type'] !== self::TOKEN_QUANTIFIER) {
+            return $node;
+        }
+
+        $this->tokenIndex++;
+        $node['quantifier'] = [
+            'min' => $token['min'],
+            'max' => $token['max'],
+            'lazy' => $token['lazy'],
+        ];
+
+        return $node;
+    }
+
+    // =========================================================================
+    // GENERATOR
+    // =========================================================================
+
+    private function generate(array $ast): string
+    {
+        $lines = ['SuperExpressive::create()'];
+
+        foreach ($ast['children'] as $node) {
+            $generated = $this->generateNode($node, 1);
+            if (\is_array($generated)) {
+                foreach ($generated as $line) {
+                    $lines[] = $line;
+                }
+            } else {
+                $lines[] = $generated;
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @return string|array
+     */
+    private function generateNode(array $node, int $indent)
+    {
+        $prefix = str_repeat('    ', $indent) . '->';
+
+        switch ($node['type']) {
+            case 'flag':
+                return $prefix . self::FLAG_MAP[$node['value']];
+
+            case 'startOfInput':
+            case 'endOfInput':
+            case 'digit':
+            case 'nonDigit':
+            case 'word':
+            case 'nonWord':
+            case 'whitespace':
+            case 'nonWhitespace':
+            case 'anyChar':
+            case 'newline':
+            case 'carriageReturn':
+            case 'tab':
+                $method = self::METHOD_MAP[$node['type']];
+                return $this->wrapWithQuantifier($prefix, $method, $node);
+
+            case 'wordBoundary':
+                return $prefix . 'wordBoundary()';
+
+            case 'nonWordBoundary':
+                return $prefix . 'nonWordBoundary()';
+
+            case 'char':
+                $escaped = $this->escapePhpString($node['value']);
+                $method = "char('{$escaped}')";
+                return $this->wrapWithQuantifier($prefix, $method, $node);
+
+            case 'string':
+                $escaped = $this->escapePhpString($node['value']);
+                return $prefix . "string('{$escaped}')";
+
+            case 'anyOfChars':
+                $escaped = $this->escapePhpString($node['value']);
+                $method = "anyOfChars('{$escaped}')";
+                return $this->wrapWithQuantifier($prefix, $method, $node);
+
+            case 'anythingButChars':
+                $escaped = $this->escapePhpString($node['value']);
+                $method = "anythingButChars('{$escaped}')";
+                return $this->wrapWithQuantifier($prefix, $method, $node);
+
+            case 'range':
+                $method = "range('{$node['from']}', '{$node['to']}')";
+                return $this->wrapWithQuantifier($prefix, $method, $node);
+
+            case 'anythingButRange':
+                $method = "anythingButRange('{$node['from']}', '{$node['to']}')";
+                return $this->wrapWithQuantifier($prefix, $method, $node);
+
+            case 'charSet':
+                return $this->generateComplexCharSet($node, $indent);
+
+            case 'group':
+            case 'capture':
+                return $this->generateGroup($node, $indent);
+
+            default:
+                return $prefix . "/* unsupported: {$node['type']} */";
+        }
+    }
+
+    private function wrapWithQuantifier(string $prefix, string $method, array $node): string
+    {
+        if (!isset($node['quantifier'])) {
+            return $prefix . $method;
+        }
+
+        $q = $node['quantifier'];
+        $quantifierMethod = $this->getQuantifierMethod($q);
+
+        return $prefix . $quantifierMethod . '->' . $method;
+    }
+
+    private function getQuantifierMethod(array $q): string
+    {
+        $min = $q['min'];
+        $max = $q['max'];
+        $lazy = $q['lazy'];
+
+        if ($min === 0 && $max === 1) {
+            return 'optional()';
+        }
+
+        if ($min === 0 && $max === null) {
+            return $lazy ? 'zeroOrMoreLazy()' : 'zeroOrMore()';
+        }
+
+        if ($min === 1 && $max === null) {
+            return $lazy ? 'oneOrMoreLazy()' : 'oneOrMore()';
+        }
+
+        if ($min === $max) {
+            return "exactly({$min})";
+        }
+
+        if ($max === null) {
+            return "atLeast({$min})";
+        }
+
+        return $lazy ? "betweenLazy({$min}, {$max})" : "between({$min}, {$max})";
+    }
+
+    private function generateComplexCharSet(array $node, int $indent): array
+    {
+        $prefix = str_repeat('    ', $indent) . '->';
+        $innerPrefix = str_repeat('    ', $indent + 1) . '->';
+
+        $lines = [];
+
+        $quantifier = isset($node['quantifier']) ? $this->getQuantifierMethod($node['quantifier']) . '->' : '';
+        $lines[] = $prefix . $quantifier . 'anyOf()';
+
+        foreach ($node['items'] as $item) {
+            if ($item['type'] === 'char') {
+                $escaped = $this->escapePhpString($item['value']);
+                $lines[] = $innerPrefix . "char('{$escaped}')";
+            } else {
+                $lines[] = $innerPrefix . "range('{$item['from']}', '{$item['to']}')";
+            }
+        }
+
+        $lines[] = $innerPrefix . 'end()';
+
+        return $lines;
+    }
+
+    private function generateGroup(array $node, int $indent): array
+    {
+        $prefix = str_repeat('    ', $indent) . '->';
+        $innerIndent = $indent + 1;
+
+        $lines = [];
+
+        $quantifier = isset($node['quantifier']) ? $this->getQuantifierMethod($node['quantifier']) . '->' : '';
+        $groupMethod = $node['type'] === 'capture' ? 'capture()' : 'group()';
+        $lines[] = $prefix . $quantifier . $groupMethod;
+
+        foreach ($node['children'] as $child) {
+            $generated = $this->generateNode($child, $innerIndent);
+            if (\is_array($generated)) {
+                foreach ($generated as $line) {
+                    $lines[] = $line;
+                }
+            } else {
+                $lines[] = $generated;
+            }
+        }
+
+        $lines[] = str_repeat('    ', $innerIndent) . '->end()';
+
+        return $lines;
+    }
+
+    private function escapePhpString(string $str): string
+    {
+        return addcslashes($str, "'\\");
+    }
+}

--- a/src/RegexParser.php
+++ b/src/RegexParser.php
@@ -4,906 +4,230 @@ declare(strict_types=1);
 
 namespace Bassim\SuperExpressive;
 
+use Bassim\SuperExpressive\Parser\Lexer;
+use Bassim\SuperExpressive\Parser\Node;
+use Bassim\SuperExpressive\Parser\Nodes\CharSetNode;
+use Bassim\SuperExpressive\Parser\Nodes\ContainerNode;
+use Bassim\SuperExpressive\Parser\Nodes\FlagNode;
+use Bassim\SuperExpressive\Parser\Nodes\LiteralNode;
+use Bassim\SuperExpressive\Parser\Nodes\SimpleNode;
+use Bassim\SuperExpressive\Parser\Quantifier;
+use Bassim\SuperExpressive\Parser\Token;
+
 final class RegexParser
 {
-    // Token types
-    private const TOKEN_ANCHOR_START = 'ANCHOR_START';
-    private const TOKEN_ANCHOR_END = 'ANCHOR_END';
-    private const TOKEN_CHAR_CLASS = 'CHAR_CLASS';
-    private const TOKEN_DOT = 'DOT';
-    private const TOKEN_CHAR_SET_START = 'CHAR_SET_START';
-    private const TOKEN_CHAR_SET_END = 'CHAR_SET_END';
-    private const TOKEN_GROUP_START = 'GROUP_START';
-    private const TOKEN_GROUP_NC_START = 'GROUP_NC_START';
-    private const TOKEN_LOOKAHEAD = 'LOOKAHEAD';
-    private const TOKEN_NEGATIVE_LOOKAHEAD = 'NEGATIVE_LOOKAHEAD';
-    private const TOKEN_LOOKBEHIND = 'LOOKBEHIND';
-    private const TOKEN_NEGATIVE_LOOKBEHIND = 'NEGATIVE_LOOKBEHIND';
-    private const TOKEN_GROUP_END = 'GROUP_END';
-    private const TOKEN_QUANTIFIER = 'QUANTIFIER';
-    private const TOKEN_LITERAL = 'LITERAL';
-
-    // Method mappings
-    private const CHAR_CLASS_MAP = [
-        'd' => 'digit',
-        'D' => 'nonDigit',
-        'w' => 'word',
-        'W' => 'nonWord',
-        's' => 'whitespace',
-        'S' => 'nonWhitespace',
+    private const CONTAINER_TOKENS = [
+        Token::GROUP_START => 'capture',
+        Token::GROUP_NC_START => 'group',
+        Token::LOOKAHEAD => 'assertAhead',
+        Token::NEGATIVE_LOOKAHEAD => 'assertNotAhead',
+        Token::LOOKBEHIND => 'assertBehind',
+        Token::NEGATIVE_LOOKBEHIND => 'assertNotBehind',
     ];
 
-    private const METHOD_MAP = [
-        'digit' => 'digit()',
-        'nonDigit' => 'nonDigit()',
-        'word' => 'word()',
-        'nonWord' => 'nonWord()',
-        'whitespace' => 'whitespaceChar()',
-        'nonWhitespace' => 'nonWhitespaceChar()',
-        'anyChar' => 'anyChar()',
-        'startOfInput' => 'startOfInput()',
-        'endOfInput' => 'endOfInput()',
-        'newline' => 'newline()',
-        'carriageReturn' => 'carriageReturn()',
-        'tab' => 'tab()',
-    ];
+    /** @var Token[] */
+    private array $tokens;
+    private int $pos = 0;
 
-    private const FLAG_MAP = [
-        'i' => 'caseInsensitive()',
-        'm' => 'lineByLine()',
-        's' => 'singleLine()',
-    ];
+    /** @var string[] */
+    private array $flags;
 
-    private string $input;
-    private string $pattern;
-    private int $position = 0;
-    private array $tokens = [];
-    private array $flags = [];
-
-    private function __construct(string $regex)
+    private function __construct(Lexer $lexer)
     {
-        $this->input = $regex;
+        $this->tokens = $lexer->tokenize();
+        $this->flags = $lexer->getFlags();
     }
 
     public static function parse(string $regex): string
     {
-        $parser = new self($regex);
-        $parser->extractDelimitersAndFlags();
-        $parser->tokenize();
-        $ast = $parser->parseTokens();
+        $lexer = new Lexer($regex);
+        $parser = new self($lexer);
+        $nodes = $parser->parseAll();
 
-        return $parser->generate($ast);
+        return self::generate($nodes);
     }
 
-    // =========================================================================
-    // LEXER
-    // =========================================================================
-
-    private function extractDelimitersAndFlags(): void
+    /**
+     * @return Node[]
+     */
+    private function parseAll(): array
     {
-        $regex = $this->input;
+        $nodes = [];
 
-        if (\strlen($regex) < 2) {
-            throw new RegexParseException('Invalid regex: too short', $regex, 0);
-        }
-
-        $delimiter = $regex[0];
-        if (!$this->isValidDelimiter($delimiter)) {
-            throw new RegexParseException("Invalid delimiter: {$delimiter}", $regex, 0);
-        }
-
-        $lastDelimiterPos = strrpos($regex, $delimiter, 1);
-        if ($lastDelimiterPos === false) {
-            throw new RegexParseException('Missing closing delimiter', $regex, \strlen($regex));
-        }
-
-        $this->pattern = substr($regex, 1, $lastDelimiterPos - 1);
-        $flagString = substr($regex, $lastDelimiterPos + 1);
-
-        for ($i = 0; $i < \strlen($flagString); $i++) {
-            $flag = $flagString[$i];
-            if (isset(self::FLAG_MAP[$flag])) {
-                $this->flags[] = $flag;
-            } elseif ($flag === 'g' || $flag === 'u' || $flag === 'y') {
-                $this->flags[] = $flag;
-            } else {
-                throw new RegexParseException("Unknown flag: {$flag}", $this->input, $lastDelimiterPos + 1 + $i);
-            }
-        }
-    }
-
-    private function isValidDelimiter(string $char): bool
-    {
-        return \in_array($char, ['/', '#', '~', '@', ';', '%', '`'], true);
-    }
-
-    private function tokenize(): void
-    {
-        $this->position = 0;
-        $this->tokens = [];
-
-        while (!$this->isAtEnd()) {
-            $token = $this->readToken();
-            if ($token !== null) {
-                $this->tokens[] = $token;
-            }
-        }
-    }
-
-    private function readToken(): ?array
-    {
-        $char = $this->peek();
-        $pos = $this->position;
-
-        // Escape sequences
-        if ($char === '\\') {
-            return $this->readEscapeSequence();
-        }
-
-        // Anchors
-        if ($char === '^') {
-            $this->advance();
-            return ['type' => self::TOKEN_ANCHOR_START, 'value' => '^', 'position' => $pos];
-        }
-
-        if ($char === '$') {
-            $this->advance();
-            return ['type' => self::TOKEN_ANCHOR_END, 'value' => '$', 'position' => $pos];
-        }
-
-        // Dot
-        if ($char === '.') {
-            $this->advance();
-            return ['type' => self::TOKEN_DOT, 'value' => '.', 'position' => $pos];
-        }
-
-        // Character set
-        if ($char === '[') {
-            return $this->readCharacterSet();
-        }
-
-        // Groups
-        if ($char === '(') {
-            $this->advance();
-            if ($this->peek() === '?' && $this->peek(1) === ':') {
-                $this->advance();
-                $this->advance();
-                return ['type' => self::TOKEN_GROUP_NC_START, 'value' => '(?:', 'position' => $pos];
-            }
-            // Lookahead: (?= and (?!
-            if ($this->peek() === '?' && $this->peek(1) === '=') {
-                $this->advance();
-                $this->advance();
-                return ['type' => self::TOKEN_LOOKAHEAD, 'value' => '(?=', 'position' => $pos];
-            }
-            if ($this->peek() === '?' && $this->peek(1) === '!') {
-                $this->advance();
-                $this->advance();
-                return ['type' => self::TOKEN_NEGATIVE_LOOKAHEAD, 'value' => '(?!', 'position' => $pos];
-            }
-            // Lookbehind: (?<= and (?<!
-            if ($this->peek() === '?' && $this->peek(1) === '<' && $this->peek(2) === '=') {
-                $this->advance();
-                $this->advance();
-                $this->advance();
-                return ['type' => self::TOKEN_LOOKBEHIND, 'value' => '(?<=', 'position' => $pos];
-            }
-            if ($this->peek() === '?' && $this->peek(1) === '<' && $this->peek(2) === '!') {
-                $this->advance();
-                $this->advance();
-                $this->advance();
-                return ['type' => self::TOKEN_NEGATIVE_LOOKBEHIND, 'value' => '(?<!', 'position' => $pos];
-            }
-            // Named groups still not supported
-            if ($this->peek() === '?') {
-                throw new RegexParseException(
-                    'Unsupported group type (named groups not supported)',
-                    $this->input,
-                    $pos
-                );
-            }
-            return ['type' => self::TOKEN_GROUP_START, 'value' => '(', 'position' => $pos];
-        }
-
-        if ($char === ')') {
-            $this->advance();
-            return ['type' => self::TOKEN_GROUP_END, 'value' => ')', 'position' => $pos];
-        }
-
-        // Quantifiers
-        if (\in_array($char, ['+', '*', '?'], true)) {
-            return $this->readQuantifier();
-        }
-
-        if ($char === '{') {
-            return $this->readBraceQuantifier();
-        }
-
-        // Alternation
-        if ($char === '|') {
-            throw new RegexParseException(
-                'Alternation (|) outside of anyOf context is not supported in v1',
-                $this->input,
-                $pos
-            );
-        }
-
-        // Literal
-        $this->advance();
-        return ['type' => self::TOKEN_LITERAL, 'value' => $char, 'position' => $pos];
-    }
-
-    private function readEscapeSequence(): array
-    {
-        $pos = $this->position;
-        $this->advance(); // consume \
-
-        $char = $this->peek();
-        if ($char === null) {
-            throw new RegexParseException('Incomplete escape sequence', $this->input, $pos);
-        }
-
-        $this->advance();
-
-        // Character classes
-        if (isset(self::CHAR_CLASS_MAP[$char])) {
-            return [
-                'type' => self::TOKEN_CHAR_CLASS,
-                'value' => self::CHAR_CLASS_MAP[$char],
-                'position' => $pos,
-            ];
-        }
-
-        // Special characters
-        if ($char === 'n') {
-            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'newline', 'position' => $pos];
-        }
-        if ($char === 'r') {
-            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'carriageReturn', 'position' => $pos];
-        }
-        if ($char === 't') {
-            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'tab', 'position' => $pos];
-        }
-
-        // Word boundary
-        if ($char === 'b') {
-            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'wordBoundary', 'position' => $pos];
-        }
-        if ($char === 'B') {
-            return ['type' => self::TOKEN_CHAR_CLASS, 'value' => 'nonWordBoundary', 'position' => $pos];
-        }
-
-        // Backreference check
-        if (ctype_digit($char)) {
-            throw new RegexParseException('Backreferences are not supported in v1', $this->input, $pos);
-        }
-
-        // Escaped literal
-        return ['type' => self::TOKEN_LITERAL, 'value' => $char, 'position' => $pos];
-    }
-
-    private function readQuantifier(): array
-    {
-        $pos = $this->position;
-        $char = $this->advance();
-        $lazy = false;
-
-        if ($this->peek() === '?') {
-            $this->advance();
-            $lazy = true;
-        }
-
-        return [
-            'type' => self::TOKEN_QUANTIFIER,
-            'value' => $char,
-            'position' => $pos,
-            'lazy' => $lazy,
-            'min' => $char === '+' ? 1 : 0,
-            'max' => $char === '?' ? 1 : null,
-        ];
-    }
-
-    private function readBraceQuantifier(): array
-    {
-        $pos = $this->position;
-        $this->advance(); // consume {
-
-        $numStr = '';
-        while ($this->peek() !== null && ctype_digit($this->peek())) {
-            $numStr .= $this->advance();
-        }
-
-        if ($numStr === '') {
-            throw new RegexParseException('Invalid quantifier: expected number', $this->input, $pos);
-        }
-
-        $min = (int) $numStr;
-        $max = $min;
-
-        if ($this->peek() === ',') {
-            $this->advance();
-            $maxStr = '';
-            while ($this->peek() !== null && ctype_digit($this->peek())) {
-                $maxStr .= $this->advance();
-            }
-            $max = $maxStr === '' ? null : (int) $maxStr;
-        }
-
-        if ($this->peek() !== '}') {
-            throw new RegexParseException('Invalid quantifier: expected }', $this->input, $this->position);
-        }
-        $this->advance();
-
-        $lazy = false;
-        if ($this->peek() === '?') {
-            $this->advance();
-            $lazy = true;
-        }
-
-        return [
-            'type' => self::TOKEN_QUANTIFIER,
-            'value' => 'brace',
-            'position' => $pos,
-            'lazy' => $lazy,
-            'min' => $min,
-            'max' => $max,
-        ];
-    }
-
-    private function readCharacterSet(): array
-    {
-        $pos = $this->position;
-        $this->advance(); // consume [
-
-        $negated = false;
-        if ($this->peek() === '^') {
-            $negated = true;
-            $this->advance();
-        }
-
-        $items = [];
-        while ($this->peek() !== null && $this->peek() !== ']') {
-            $char = $this->peek();
-
-            if ($char === '\\') {
-                $this->advance();
-                $escaped = $this->advance();
-                if ($escaped === null) {
-                    throw new RegexParseException('Incomplete escape in character set', $this->input, $this->position);
-                }
-                $char = $this->resolveEscapeInCharSet($escaped);
-            } else {
-                $this->advance();
-            }
-
-            // Check for range
-            if ($this->peek() === '-' && $this->peek(1) !== null && $this->peek(1) !== ']') {
-                $this->advance(); // consume -
-                $endChar = $this->peek();
-                if ($endChar === '\\') {
-                    $this->advance();
-                    $endChar = $this->resolveEscapeInCharSet($this->advance());
-                } else {
-                    $this->advance();
-                }
-                $items[] = ['type' => 'range', 'from' => $char, 'to' => $endChar];
-            } else {
-                $items[] = ['type' => 'char', 'value' => $char];
-            }
-        }
-
-        if ($this->peek() !== ']') {
-            throw new RegexParseException('Unclosed character set', $this->input, $pos);
-        }
-        $this->advance();
-
-        return [
-            'type' => self::TOKEN_CHAR_SET_START,
-            'value' => $items,
-            'position' => $pos,
-            'negated' => $negated,
-        ];
-    }
-
-    private function resolveEscapeInCharSet(string $char): string
-    {
-        $map = ['n' => "\n", 'r' => "\r", 't' => "\t", '\\' => '\\', ']' => ']', '[' => '[', '-' => '-', '^' => '^'];
-        return $map[$char] ?? $char;
-    }
-
-    private function peek(int $offset = 0): ?string
-    {
-        $pos = $this->position + $offset;
-        return $pos < \strlen($this->pattern) ? $this->pattern[$pos] : null;
-    }
-
-    private function advance(): ?string
-    {
-        if ($this->isAtEnd()) {
-            return null;
-        }
-        return $this->pattern[$this->position++];
-    }
-
-    private function isAtEnd(): bool
-    {
-        return $this->position >= \strlen($this->pattern);
-    }
-
-    // =========================================================================
-    // PARSER
-    // =========================================================================
-
-    private int $tokenIndex = 0;
-
-    private function parseTokens(): array
-    {
-        $this->tokenIndex = 0;
-        $children = [];
-
-        // Add flags first
+        // Flags first
         foreach ($this->flags as $flag) {
-            if (isset(self::FLAG_MAP[$flag])) {
-                $children[] = ['type' => 'flag', 'value' => $flag];
+            if (\in_array($flag, ['i', 'm', 's'], true)) {
+                $nodes[] = new FlagNode($flag);
             }
         }
 
         // Parse expression
-        while ($this->tokenIndex < \count($this->tokens)) {
-            $node = $this->parseAtom();
+        while ($this->pos < \count($this->tokens)) {
+            $node = $this->parseNode();
             if ($node !== null) {
-                $children[] = $node;
+                $nodes[] = $node;
             }
         }
 
-        return ['type' => 'root', 'children' => $children];
+        return $nodes;
     }
 
-    private function parseAtom(): ?array
+    private function parseNode(): ?Node
     {
-        if ($this->tokenIndex >= \count($this->tokens)) {
+        $token = $this->current();
+        if ($token === null) {
             return null;
         }
 
-        $token = $this->tokens[$this->tokenIndex];
+        // Handle by token type
+        switch ($token->type) {
+            case Token::ANCHOR_START:
+                $this->pos++;
+                return new SimpleNode('startOfInput');
 
-        switch ($token['type']) {
-            case self::TOKEN_ANCHOR_START:
-                $this->tokenIndex++;
-                return ['type' => 'startOfInput'];
+            case Token::ANCHOR_END:
+                $this->pos++;
+                return new SimpleNode('endOfInput');
 
-            case self::TOKEN_ANCHOR_END:
-                $this->tokenIndex++;
-                return ['type' => 'endOfInput'];
+            case Token::CHAR_CLASS:
+                $this->pos++;
+                return $this->withQuantifier(new SimpleNode($token->value));
 
-            case self::TOKEN_CHAR_CLASS:
-                $this->tokenIndex++;
-                $node = ['type' => $token['value']];
-                return $this->applyQuantifierIfPresent($node);
+            case Token::DOT:
+                $this->pos++;
+                return $this->withQuantifier(new SimpleNode('anyChar'));
 
-            case self::TOKEN_DOT:
-                $this->tokenIndex++;
-                $node = ['type' => 'anyChar'];
-                return $this->applyQuantifierIfPresent($node);
-
-            case self::TOKEN_LITERAL:
+            case Token::LITERAL:
                 return $this->parseLiterals();
 
-            case self::TOKEN_CHAR_SET_START:
-                $this->tokenIndex++;
-                $node = $this->buildCharSetNode($token);
-                return $this->applyQuantifierIfPresent($node);
+            case Token::CHAR_SET:
+                $this->pos++;
+                $node = new CharSetNode($token->value, $token->meta['negated']);
+                return $this->withQuantifier($node);
 
-            case self::TOKEN_GROUP_START:
-            case self::TOKEN_GROUP_NC_START:
-                return $this->parseGroup($token['type'] === self::TOKEN_GROUP_START);
-
-            case self::TOKEN_LOOKAHEAD:
-                return $this->parseAssertion('assertAhead');
-
-            case self::TOKEN_NEGATIVE_LOOKAHEAD:
-                return $this->parseAssertion('assertNotAhead');
-
-            case self::TOKEN_LOOKBEHIND:
-                return $this->parseAssertion('assertBehind');
-
-            case self::TOKEN_NEGATIVE_LOOKBEHIND:
-                return $this->parseAssertion('assertNotBehind');
-
-            case self::TOKEN_GROUP_END:
+            case Token::GROUP_END:
                 return null;
 
-            case self::TOKEN_QUANTIFIER:
+            case Token::QUANTIFIER:
                 throw new RegexParseException(
-                    'Unexpected quantifier without preceding element',
-                    $this->input,
-                    $token['position']
+                    'Unexpected quantifier',
+                    '',
+                    $token->position
                 );
 
             default:
-                $this->tokenIndex++;
+                // Container tokens (groups, assertions)
+                if (isset(self::CONTAINER_TOKENS[$token->type])) {
+                    return $this->parseContainer($token);
+                }
+                $this->pos++;
                 return null;
         }
     }
 
-    private function parseLiterals(): array
+    private function parseLiterals(): Node
     {
         $literals = '';
-        $startPos = $this->tokenIndex;
 
-        // Collect consecutive literals
-        while ($this->tokenIndex < \count($this->tokens)) {
-            $token = $this->tokens[$this->tokenIndex];
-            if ($token['type'] !== self::TOKEN_LITERAL) {
+        while ($this->pos < \count($this->tokens)) {
+            $token = $this->current();
+            if (!$token->is(Token::LITERAL)) {
                 break;
             }
 
-            // Check if next token is a quantifier
-            $nextToken = $this->tokens[$this->tokenIndex + 1] ?? null;
-            if ($nextToken && $nextToken['type'] === self::TOKEN_QUANTIFIER) {
-                // If we have accumulated literals, return them first
+            // Peek ahead for quantifier
+            $next = $this->peek();
+            if ($next !== null && $next->is(Token::QUANTIFIER)) {
                 if (\strlen($literals) > 0) {
-                    break;
+                    break; // Return accumulated string first
                 }
-                // Otherwise, this single char gets quantified
-                $this->tokenIndex++;
-                $node = ['type' => 'char', 'value' => $token['value']];
-                return $this->applyQuantifierIfPresent($node);
+                // Single char with quantifier
+                $this->pos++;
+                $node = new LiteralNode($token->value);
+                return $this->withQuantifier($node);
             }
 
-            $literals .= $token['value'];
-            $this->tokenIndex++;
+            $literals .= $token->value;
+            $this->pos++;
         }
 
-        if (\strlen($literals) === 1) {
-            return ['type' => 'char', 'value' => $literals];
-        }
-
-        return ['type' => 'string', 'value' => $literals];
+        return new LiteralNode($literals);
     }
 
-    private function buildCharSetNode(array $token): array
+    private function parseContainer(Token $startToken): Node
     {
-        $items = $token['value'];
-        $negated = $token['negated'];
-
-        // Optimize: simple chars only
-        $allChars = true;
-        $chars = '';
-        foreach ($items as $item) {
-            if ($item['type'] === 'char') {
-                $chars .= $item['value'];
-            } else {
-                $allChars = false;
-                break;
-            }
-        }
-
-        if ($allChars && \strlen($chars) > 0) {
-            return [
-                'type' => $negated ? 'anythingButChars' : 'anyOfChars',
-                'value' => $chars,
-            ];
-        }
-
-        // Single range
-        if (\count($items) === 1 && $items[0]['type'] === 'range') {
-            if ($negated) {
-                return [
-                    'type' => 'anythingButRange',
-                    'from' => $items[0]['from'],
-                    'to' => $items[0]['to'],
-                ];
-            }
-            return [
-                'type' => 'range',
-                'from' => $items[0]['from'],
-                'to' => $items[0]['to'],
-            ];
-        }
-
-        // Complex: use anyOf
-        return [
-            'type' => 'charSet',
-            'items' => $items,
-            'negated' => $negated,
-        ];
-    }
-
-    private function parseGroup(bool $capturing): array
-    {
-        $this->tokenIndex++; // consume group start
+        $type = self::CONTAINER_TOKENS[$startToken->type];
+        $this->pos++;
 
         $children = [];
-        while ($this->tokenIndex < \count($this->tokens)) {
-            $token = $this->tokens[$this->tokenIndex];
-            if ($token['type'] === self::TOKEN_GROUP_END) {
-                $this->tokenIndex++;
+        while ($this->pos < \count($this->tokens)) {
+            $token = $this->current();
+            if ($token->is(Token::GROUP_END)) {
+                $this->pos++;
                 break;
             }
-            $node = $this->parseAtom();
+            $node = $this->parseNode();
             if ($node !== null) {
                 $children[] = $node;
             }
         }
 
-        $node = [
-            'type' => $capturing ? 'capture' : 'group',
-            'children' => $children,
-        ];
+        $container = new ContainerNode($type, $children);
 
-        return $this->applyQuantifierIfPresent($node);
-    }
-
-    private function parseAssertion(string $type): array
-    {
-        $this->tokenIndex++; // consume assertion start
-
-        $children = [];
-        while ($this->tokenIndex < \count($this->tokens)) {
-            $token = $this->tokens[$this->tokenIndex];
-            if ($token['type'] === self::TOKEN_GROUP_END) {
-                $this->tokenIndex++;
-                break;
-            }
-            $node = $this->parseAtom();
-            if ($node !== null) {
-                $children[] = $node;
-            }
+        // Assertions can't have quantifiers, groups can
+        if (\in_array($type, ['group', 'capture'], true)) {
+            return $this->withQuantifier($container);
         }
 
-        // Assertions cannot have quantifiers
-        return [
-            'type' => $type,
-            'children' => $children,
-        ];
+        return $container;
     }
 
-    private function applyQuantifierIfPresent(array $node): array
+    private function withQuantifier(Node $node): Node
     {
-        if ($this->tokenIndex >= \count($this->tokens)) {
+        $next = $this->current();
+        if ($next === null || !$next->is(Token::QUANTIFIER)) {
             return $node;
         }
 
-        $token = $this->tokens[$this->tokenIndex];
-        if ($token['type'] !== self::TOKEN_QUANTIFIER) {
-            return $node;
-        }
+        $this->pos++;
+        $quantifier = new Quantifier(
+            $next->meta['min'],
+            $next->meta['max'],
+            $next->meta['lazy']
+        );
 
-        $this->tokenIndex++;
-        $node['quantifier'] = [
-            'min' => $token['min'],
-            'max' => $token['max'],
-            'lazy' => $token['lazy'],
-        ];
-
-        return $node;
+        return $node->quantify($quantifier);
     }
 
-    // =========================================================================
-    // GENERATOR
-    // =========================================================================
+    private function current(): ?Token
+    {
+        return $this->tokens[$this->pos] ?? null;
+    }
 
-    private function generate(array $ast): string
+    private function peek(): ?Token
+    {
+        return $this->tokens[$this->pos + 1] ?? null;
+    }
+
+    /**
+     * @param Node[] $nodes
+     */
+    private static function generate(array $nodes): string
     {
         $lines = ['SuperExpressive::create()'];
 
-        foreach ($ast['children'] as $node) {
-            $generated = $this->generateNode($node, 1);
-            if (\is_array($generated)) {
-                foreach ($generated as $line) {
-                    $lines[] = $line;
+        foreach ($nodes as $node) {
+            $code = $node->toSuperExpressive();
+            foreach (explode("\n", $code) as $line) {
+                if ($line !== '') {
+                    // Preserve existing indentation, add -> after it
+                    $trimmed = ltrim($line);
+                    $indent = \strlen($line) - \strlen($trimmed);
+                    $lines[] = '    ' . str_repeat(' ', $indent) . '->' . $trimmed;
                 }
-            } else {
-                $lines[] = $generated;
             }
         }
 
         return implode("\n", $lines);
-    }
-
-    /**
-     * @return string|array
-     */
-    private function generateNode(array $node, int $indent)
-    {
-        $prefix = str_repeat('    ', $indent) . '->';
-
-        switch ($node['type']) {
-            case 'flag':
-                return $prefix . self::FLAG_MAP[$node['value']];
-
-            case 'startOfInput':
-            case 'endOfInput':
-            case 'digit':
-            case 'nonDigit':
-            case 'word':
-            case 'nonWord':
-            case 'whitespace':
-            case 'nonWhitespace':
-            case 'anyChar':
-            case 'newline':
-            case 'carriageReturn':
-            case 'tab':
-                $method = self::METHOD_MAP[$node['type']];
-                return $this->wrapWithQuantifier($prefix, $method, $node);
-
-            case 'wordBoundary':
-                return $prefix . 'wordBoundary()';
-
-            case 'nonWordBoundary':
-                return $prefix . 'nonWordBoundary()';
-
-            case 'char':
-                $escaped = $this->escapePhpString($node['value']);
-                $method = "char('{$escaped}')";
-                return $this->wrapWithQuantifier($prefix, $method, $node);
-
-            case 'string':
-                $escaped = $this->escapePhpString($node['value']);
-                return $prefix . "string('{$escaped}')";
-
-            case 'anyOfChars':
-                $escaped = $this->escapePhpString($node['value']);
-                $method = "anyOfChars('{$escaped}')";
-                return $this->wrapWithQuantifier($prefix, $method, $node);
-
-            case 'anythingButChars':
-                $escaped = $this->escapePhpString($node['value']);
-                $method = "anythingButChars('{$escaped}')";
-                return $this->wrapWithQuantifier($prefix, $method, $node);
-
-            case 'range':
-                $method = "range('{$node['from']}', '{$node['to']}')";
-                return $this->wrapWithQuantifier($prefix, $method, $node);
-
-            case 'anythingButRange':
-                $method = "anythingButRange('{$node['from']}', '{$node['to']}')";
-                return $this->wrapWithQuantifier($prefix, $method, $node);
-
-            case 'charSet':
-                return $this->generateComplexCharSet($node, $indent);
-
-            case 'group':
-            case 'capture':
-                return $this->generateGroup($node, $indent);
-
-            case 'assertAhead':
-            case 'assertNotAhead':
-            case 'assertBehind':
-            case 'assertNotBehind':
-                return $this->generateAssertion($node, $indent);
-
-            default:
-                return $prefix . "/* unsupported: {$node['type']} */";
-        }
-    }
-
-    private function wrapWithQuantifier(string $prefix, string $method, array $node): string
-    {
-        if (!isset($node['quantifier'])) {
-            return $prefix . $method;
-        }
-
-        $q = $node['quantifier'];
-        $quantifierMethod = $this->getQuantifierMethod($q);
-
-        return $prefix . $quantifierMethod . '->' . $method;
-    }
-
-    private function getQuantifierMethod(array $q): string
-    {
-        $min = $q['min'];
-        $max = $q['max'];
-        $lazy = $q['lazy'];
-
-        if ($min === 0 && $max === 1) {
-            return 'optional()';
-        }
-
-        if ($min === 0 && $max === null) {
-            return $lazy ? 'zeroOrMoreLazy()' : 'zeroOrMore()';
-        }
-
-        if ($min === 1 && $max === null) {
-            return $lazy ? 'oneOrMoreLazy()' : 'oneOrMore()';
-        }
-
-        if ($min === $max) {
-            return "exactly({$min})";
-        }
-
-        if ($max === null) {
-            return "atLeast({$min})";
-        }
-
-        return $lazy ? "betweenLazy({$min}, {$max})" : "between({$min}, {$max})";
-    }
-
-    private function generateComplexCharSet(array $node, int $indent): array
-    {
-        $prefix = str_repeat('    ', $indent) . '->';
-        $innerPrefix = str_repeat('    ', $indent + 1) . '->';
-
-        $lines = [];
-
-        $quantifier = isset($node['quantifier']) ? $this->getQuantifierMethod($node['quantifier']) . '->' : '';
-        $lines[] = $prefix . $quantifier . 'anyOf()';
-
-        foreach ($node['items'] as $item) {
-            if ($item['type'] === 'char') {
-                $escaped = $this->escapePhpString($item['value']);
-                $lines[] = $innerPrefix . "char('{$escaped}')";
-            } else {
-                $lines[] = $innerPrefix . "range('{$item['from']}', '{$item['to']}')";
-            }
-        }
-
-        $lines[] = $innerPrefix . 'end()';
-
-        return $lines;
-    }
-
-    private function generateGroup(array $node, int $indent): array
-    {
-        $prefix = str_repeat('    ', $indent) . '->';
-        $innerIndent = $indent + 1;
-
-        $lines = [];
-
-        $quantifier = isset($node['quantifier']) ? $this->getQuantifierMethod($node['quantifier']) . '->' : '';
-        $groupMethod = $node['type'] === 'capture' ? 'capture()' : 'group()';
-        $lines[] = $prefix . $quantifier . $groupMethod;
-
-        foreach ($node['children'] as $child) {
-            $generated = $this->generateNode($child, $innerIndent);
-            if (\is_array($generated)) {
-                foreach ($generated as $line) {
-                    $lines[] = $line;
-                }
-            } else {
-                $lines[] = $generated;
-            }
-        }
-
-        $lines[] = str_repeat('    ', $innerIndent) . '->end()';
-
-        return $lines;
-    }
-
-    private function generateAssertion(array $node, int $indent): array
-    {
-        $prefix = str_repeat('    ', $indent) . '->';
-        $innerIndent = $indent + 1;
-
-        $methodMap = [
-            'assertAhead' => 'assertAhead()',
-            'assertNotAhead' => 'assertNotAhead()',
-            'assertBehind' => 'assertBehind()',
-            'assertNotBehind' => 'assertNotBehind()',
-        ];
-
-        $lines = [];
-        $lines[] = $prefix . $methodMap[$node['type']];
-
-        foreach ($node['children'] as $child) {
-            $generated = $this->generateNode($child, $innerIndent);
-            if (\is_array($generated)) {
-                foreach ($generated as $line) {
-                    $lines[] = $line;
-                }
-            } else {
-                $lines[] = $generated;
-            }
-        }
-
-        $lines[] = str_repeat('    ', $innerIndent) . '->end()';
-
-        return $lines;
-    }
-
-    private function escapePhpString(string $str): string
-    {
-        return addcslashes($str, "'\\");
     }
 }

--- a/tests/RegexParserTest.php
+++ b/tests/RegexParserTest.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bassim\SuperExpressive\Tests;
+
+use Bassim\SuperExpressive\RegexParser;
+use Bassim\SuperExpressive\RegexParseException;
+use PHPUnit\Framework\TestCase;
+
+final class RegexParserTest extends TestCase
+{
+    // =========================================================================
+    // ANCHORS
+    // =========================================================================
+
+    public function testParseStartAnchor(): void
+    {
+        $result = RegexParser::parse('/^/');
+        static::assertStringContainsString('startOfInput()', $result);
+    }
+
+    public function testParseEndAnchor(): void
+    {
+        $result = RegexParser::parse('/$/');
+        static::assertStringContainsString('endOfInput()', $result);
+    }
+
+    public function testParseBothAnchors(): void
+    {
+        $result = RegexParser::parse('/^$/');
+        static::assertStringContainsString('startOfInput()', $result);
+        static::assertStringContainsString('endOfInput()', $result);
+    }
+
+    // =========================================================================
+    // CHARACTER CLASSES
+    // =========================================================================
+
+    public function testParseDigit(): void
+    {
+        $result = RegexParser::parse('/\d/');
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    public function testParseNonDigit(): void
+    {
+        $result = RegexParser::parse('/\D/');
+        static::assertStringContainsString('nonDigit()', $result);
+    }
+
+    public function testParseWord(): void
+    {
+        $result = RegexParser::parse('/\w/');
+        static::assertStringContainsString('word()', $result);
+    }
+
+    public function testParseNonWord(): void
+    {
+        $result = RegexParser::parse('/\W/');
+        static::assertStringContainsString('nonWord()', $result);
+    }
+
+    public function testParseWhitespace(): void
+    {
+        $result = RegexParser::parse('/\s/');
+        static::assertStringContainsString('whitespaceChar()', $result);
+    }
+
+    public function testParseNonWhitespace(): void
+    {
+        $result = RegexParser::parse('/\S/');
+        static::assertStringContainsString('nonWhitespaceChar()', $result);
+    }
+
+    public function testParseDot(): void
+    {
+        $result = RegexParser::parse('/./');
+        static::assertStringContainsString('anyChar()', $result);
+    }
+
+    // =========================================================================
+    // SPECIAL CHARACTERS
+    // =========================================================================
+
+    public function testParseNewline(): void
+    {
+        $result = RegexParser::parse('/\n/');
+        static::assertStringContainsString('newline()', $result);
+    }
+
+    public function testParseTab(): void
+    {
+        $result = RegexParser::parse('/\t/');
+        static::assertStringContainsString('tab()', $result);
+    }
+
+    public function testParseCarriageReturn(): void
+    {
+        $result = RegexParser::parse('/\r/');
+        static::assertStringContainsString('carriageReturn()', $result);
+    }
+
+    // =========================================================================
+    // QUANTIFIERS
+    // =========================================================================
+
+    public function testParseOneOrMore(): void
+    {
+        $result = RegexParser::parse('/\d+/');
+        static::assertStringContainsString('oneOrMore()', $result);
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    public function testParseZeroOrMore(): void
+    {
+        $result = RegexParser::parse('/\d*/');
+        static::assertStringContainsString('zeroOrMore()', $result);
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    public function testParseOptional(): void
+    {
+        $result = RegexParser::parse('/\d?/');
+        static::assertStringContainsString('optional()', $result);
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    public function testParseExactly(): void
+    {
+        $result = RegexParser::parse('/\d{3}/');
+        static::assertStringContainsString('exactly(3)', $result);
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    public function testParseAtLeast(): void
+    {
+        $result = RegexParser::parse('/\d{3,}/');
+        static::assertStringContainsString('atLeast(3)', $result);
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    public function testParseBetween(): void
+    {
+        $result = RegexParser::parse('/\d{3,5}/');
+        static::assertStringContainsString('between(3, 5)', $result);
+        static::assertStringContainsString('digit()', $result);
+    }
+
+    // =========================================================================
+    // LAZY QUANTIFIERS
+    // =========================================================================
+
+    public function testParseOneOrMoreLazy(): void
+    {
+        $result = RegexParser::parse('/\d+?/');
+        static::assertStringContainsString('oneOrMoreLazy()', $result);
+    }
+
+    public function testParseZeroOrMoreLazy(): void
+    {
+        $result = RegexParser::parse('/\d*?/');
+        static::assertStringContainsString('zeroOrMoreLazy()', $result);
+    }
+
+    public function testParseBetweenLazy(): void
+    {
+        $result = RegexParser::parse('/\d{3,5}?/');
+        static::assertStringContainsString('betweenLazy(3, 5)', $result);
+    }
+
+    // =========================================================================
+    // CHARACTER SETS
+    // =========================================================================
+
+    public function testParseSimpleCharSet(): void
+    {
+        $result = RegexParser::parse('/[abc]/');
+        static::assertStringContainsString("anyOfChars('abc')", $result);
+    }
+
+    public function testParseNegatedCharSet(): void
+    {
+        $result = RegexParser::parse('/[^abc]/');
+        static::assertStringContainsString("anythingButChars('abc')", $result);
+    }
+
+    public function testParseCharRange(): void
+    {
+        $result = RegexParser::parse('/[a-z]/');
+        static::assertStringContainsString("range('a', 'z')", $result);
+    }
+
+    public function testParseNegatedCharRange(): void
+    {
+        $result = RegexParser::parse('/[^0-9]/');
+        static::assertStringContainsString("anythingButRange('0', '9')", $result);
+    }
+
+    public function testParseComplexCharSet(): void
+    {
+        $result = RegexParser::parse('/[a-zA-Z0-9]/');
+        static::assertStringContainsString('anyOf()', $result);
+        static::assertStringContainsString("range('a', 'z')", $result);
+        static::assertStringContainsString("range('A', 'Z')", $result);
+        static::assertStringContainsString("range('0', '9')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    // =========================================================================
+    // GROUPS
+    // =========================================================================
+
+    public function testParseNonCapturingGroup(): void
+    {
+        $result = RegexParser::parse('/(?:abc)/');
+        static::assertStringContainsString('group()', $result);
+        static::assertStringContainsString("string('abc')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    public function testParseCapturingGroup(): void
+    {
+        $result = RegexParser::parse('/(abc)/');
+        static::assertStringContainsString('capture()', $result);
+        static::assertStringContainsString("string('abc')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    public function testParseGroupWithQuantifier(): void
+    {
+        $result = RegexParser::parse('/(?:abc)+/');
+        static::assertStringContainsString('oneOrMore()->group()', $result);
+    }
+
+    // =========================================================================
+    // LITERALS
+    // =========================================================================
+
+    public function testParseLiteralString(): void
+    {
+        $result = RegexParser::parse('/hello/');
+        static::assertStringContainsString("string('hello')", $result);
+    }
+
+    public function testParseSingleChar(): void
+    {
+        $result = RegexParser::parse('/a/');
+        static::assertStringContainsString("char('a')", $result);
+    }
+
+    public function testParseSingleCharWithQuantifier(): void
+    {
+        $result = RegexParser::parse('/a+/');
+        static::assertStringContainsString('oneOrMore()', $result);
+        static::assertStringContainsString("char('a')", $result);
+    }
+
+    public function testParseEscapedSpecialChars(): void
+    {
+        $result = RegexParser::parse('/\./');
+        static::assertStringContainsString("char('.')", $result);
+    }
+
+    // =========================================================================
+    // FLAGS
+    // =========================================================================
+
+    public function testParseCaseInsensitiveFlag(): void
+    {
+        $result = RegexParser::parse('/abc/i');
+        static::assertStringContainsString('caseInsensitive()', $result);
+    }
+
+    public function testParseMultilineFlag(): void
+    {
+        $result = RegexParser::parse('/abc/m');
+        static::assertStringContainsString('lineByLine()', $result);
+    }
+
+    public function testParseSingleLineFlag(): void
+    {
+        $result = RegexParser::parse('/abc/s');
+        static::assertStringContainsString('singleLine()', $result);
+    }
+
+    public function testParseMultipleFlags(): void
+    {
+        $result = RegexParser::parse('/abc/ims');
+        static::assertStringContainsString('caseInsensitive()', $result);
+        static::assertStringContainsString('lineByLine()', $result);
+        static::assertStringContainsString('singleLine()', $result);
+    }
+
+    // =========================================================================
+    // COMPLEX PATTERNS
+    // =========================================================================
+
+    public function testParseEmailLikePattern(): void
+    {
+        $result = RegexParser::parse('/^\w+@\w+\.\w+$/');
+        static::assertStringContainsString('startOfInput()', $result);
+        static::assertStringContainsString('oneOrMore()->word()', $result);
+        static::assertStringContainsString("char('@')", $result);
+        static::assertStringContainsString("char('.')", $result);
+        static::assertStringContainsString('endOfInput()', $result);
+    }
+
+    public function testParsePhonePattern(): void
+    {
+        $result = RegexParser::parse('/^\d{3}-\d{4}$/');
+        static::assertStringContainsString('startOfInput()', $result);
+        static::assertStringContainsString('exactly(3)->digit()', $result);
+        static::assertStringContainsString("char('-')", $result);
+        static::assertStringContainsString('exactly(4)->digit()', $result);
+        static::assertStringContainsString('endOfInput()', $result);
+    }
+
+    // =========================================================================
+    // ERROR HANDLING
+    // =========================================================================
+
+    public function testErrorOnInvalidDelimiter(): void
+    {
+        $this->expectException(RegexParseException::class);
+        RegexParser::parse('abc');
+    }
+
+    public function testErrorOnMissingClosingDelimiter(): void
+    {
+        $this->expectException(RegexParseException::class);
+        RegexParser::parse('/abc');
+    }
+
+    public function testErrorOnUnclosedCharacterSet(): void
+    {
+        $this->expectException(RegexParseException::class);
+        RegexParser::parse('/[abc/');
+    }
+
+    public function testErrorOnLookahead(): void
+    {
+        $this->expectException(RegexParseException::class);
+        $this->expectExceptionMessage('lookahead');
+        RegexParser::parse('/(?=abc)/');
+    }
+
+    public function testErrorOnBackreference(): void
+    {
+        $this->expectException(RegexParseException::class);
+        $this->expectExceptionMessage('Backreference');
+        RegexParser::parse('/(\w)\1/');
+    }
+
+    public function testErrorOnAlternation(): void
+    {
+        $this->expectException(RegexParseException::class);
+        $this->expectExceptionMessage('Alternation');
+        RegexParser::parse('/a|b/');
+    }
+
+    // =========================================================================
+    // ROUND-TRIP TESTS
+    // =========================================================================
+
+    /**
+     * @dataProvider roundTripProvider
+     */
+    public function testRoundTrip(string $regex): void
+    {
+        $code = RegexParser::parse($regex);
+        $generatedRegex = eval('use Bassim\SuperExpressive\SuperExpressive; return ' . $code . '->toRegexString();');
+
+        static::assertEquals($regex, $generatedRegex, "Round-trip failed for: {$regex}\nGenerated code:\n{$code}");
+    }
+
+    public function roundTripProvider(): array
+    {
+        return [
+            'simple digit' => ['/\d/'],
+            'digit with quantifier' => ['/\d+/'],
+            'anchored pattern' => ['/^\d+$/'],
+            'character class' => ['/[a-z]/'],
+            'escaped dot' => ['/\./'],
+            'simple group' => ['/(?:abc)/'],
+        ];
+    }
+}

--- a/tests/RegexParserTest.php
+++ b/tests/RegexParserTest.php
@@ -293,6 +293,58 @@ final class RegexParserTest extends TestCase
     }
 
     // =========================================================================
+    // LOOKAHEAD / LOOKBEHIND
+    // =========================================================================
+
+    public function testParseLookahead(): void
+    {
+        $result = RegexParser::parse('/(?=abc)/');
+        static::assertStringContainsString('assertAhead()', $result);
+        static::assertStringContainsString("string('abc')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    public function testParseNegativeLookahead(): void
+    {
+        $result = RegexParser::parse('/(?!abc)/');
+        static::assertStringContainsString('assertNotAhead()', $result);
+        static::assertStringContainsString("string('abc')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    public function testParseLookbehind(): void
+    {
+        $result = RegexParser::parse('/(?<=abc)/');
+        static::assertStringContainsString('assertBehind()', $result);
+        static::assertStringContainsString("string('abc')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    public function testParseNegativeLookbehind(): void
+    {
+        $result = RegexParser::parse('/(?<!abc)/');
+        static::assertStringContainsString('assertNotBehind()', $result);
+        static::assertStringContainsString("string('abc')", $result);
+        static::assertStringContainsString('end()', $result);
+    }
+
+    public function testParseLookaheadWithPattern(): void
+    {
+        $result = RegexParser::parse('/\d+(?=px)/');
+        static::assertStringContainsString('oneOrMore()->digit()', $result);
+        static::assertStringContainsString('assertAhead()', $result);
+        static::assertStringContainsString("string('px')", $result);
+    }
+
+    public function testParseLookbehindWithPattern(): void
+    {
+        $result = RegexParser::parse('/(?<=\$)\d+/');
+        static::assertStringContainsString('assertBehind()', $result);
+        static::assertStringContainsString("char('\$')", $result);
+        static::assertStringContainsString('oneOrMore()->digit()', $result);
+    }
+
+    // =========================================================================
     // COMPLEX PATTERNS
     // =========================================================================
 
@@ -336,13 +388,6 @@ final class RegexParserTest extends TestCase
     {
         $this->expectException(RegexParseException::class);
         RegexParser::parse('/[abc/');
-    }
-
-    public function testErrorOnLookahead(): void
-    {
-        $this->expectException(RegexParseException::class);
-        $this->expectExceptionMessage('lookahead');
-        RegexParser::parse('/(?=abc)/');
     }
 
     public function testErrorOnBackreference(): void


### PR DESCRIPTION
## Summary
- Add `RegexParser` class that converts regex strings to copy-pasteable SuperExpressive PHP code
- Add `RegexParseException` for detailed parse error messages
- Add comprehensive test suite (52 tests)

## Usage
```php
use Bassim\SuperExpressive\RegexParser;

$code = RegexParser::parse('/^\d{3}-\d{4}$/');
```

Output:
```php
SuperExpressive::create()
    ->startOfInput()
    ->exactly(3)->digit()
    ->char('-')
    ->exactly(4)->digit()
    ->endOfInput()
```

## Supported Features (v1)
- Anchors: `^` `$`
- Character classes: `\d` `\D` `\w` `\W` `\s` `\S` `.`
- Quantifiers: `+` `*` `?` `{n}` `{n,}` `{n,m}`
- Lazy quantifiers: `+?` `*?` `{n,m}?`
- Character sets: `[abc]` `[^abc]` `[a-z]`
- Groups: `(?:...)` `(...)`
- Flags: `i` `m` `s`

## Test plan
- [x] All 52 new RegexParser tests pass
- [x] All 96 total tests pass
- [x] Round-trip tests verify generated code produces same regex

🤖 Generated with [Claude Code](https://claude.ai/code)